### PR TITLE
docs: add DeepWiki badge for AI-powered project documentation

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,4 +1,4 @@
-# Learn Agentic AI using Dapr Agentic Cloud Ascent (DACA) Design Pattern: From Start to Scale
+# Learn Agentic AI using Dapr Agentic Cloud Ascent (DACA) Design Pattern: From Start to Scale [![Ask DeepWiki](https://deepwiki.com/badge.svg)](https://deepwiki.com/panaversity/learn-agentic-ai)
 
 This repo is part of the [Panaversity Certified Agentic & Robotic AI Engineer](https://docs.google.com/document/d/15usu1hkrrRLRjcq_3nCTT-0ljEcgiC44iSdvdqrCprk/edit?usp=sharing) program. It covers AI-201, AI-202 and AI-301 courses.
 


### PR DESCRIPTION
### What
This PR adds the official “Ask DeepWiki” badge to the top of our README.

### Why
DeepWiki is an AI-powered docs layer that continuously indexes your public GitHub repo to generate searchable, wiki-style pages, interactive Q&A, and visual architecture diagrams—*all without any manual upkeep*. Adding this badge unlocks:

- **Instant AI docs:** One click takes you to DeepWiki’s structured documentation and module overviews.  
- **Interactive Q&A assistant:** Ask questions (“How does tracing work?”) and receive code-aware answers.  
- **Visual architecture diagrams:** Auto-rendered flowcharts and dependency graphs for at-a-glance clarity.  
- **Zero-maintenance updates:** DeepWiki’s crawler auto-syncs docs on every commit or weekly by default.  
- **Free for open-source:** No cost to use DeepWiki on public repositories.  
- **Effortless setup:** Activate by replacing `github.com` with `deepwiki.com`—no installs or config needed.  
- **Reduced onboarding time:** New contributors ramp up faster via an always-fresh, AI-driven docs portal.

### Changes
- Inserted the markdown badge at the top of the README:
  ```md
  [![Ask DeepWiki](https://deepwiki.com/badge.svg)](https://deepwiki.com/openai/openai-agents-python)
