### PR TITLE
Add Resource Templates Discovery to MCP Example

### DIFF
--- a/03_ai_protocols/02_model_context_protocol/01_server_development/03_exposing_resources/my_resources_server/client.py
+++ b/03_ai_protocols/02_model_context_protocol/01_server_development/03_exposing_resources/my_resources_server/client.py
@@ -3,7 +3,7 @@ import json
 import asyncio
 
 # --- Helper Function to Make MCP Requests ---
-async def _mcp_request(method: str, params: dict = None):
+async def _mcp_request(method: str, params: dict = {}):
     """A simple, reusable function to make JSON-RPC requests to our MCP server."""
     payload = {
         "jsonrpc": "2.0",
@@ -48,9 +48,23 @@ async def main():
     print(f"   -> Success! Server has {len(resources)} resources:")
     for res in resources:
         print(f"      - {res.get('uri')}: {res.get('description')}")
+        
+        
+    # 2. Listing  Resource Templates
+    print("\n[Step 2: Discovering Resource Templates]")
+    print("We ask the server what templates resources it has with a 'resources/templates/list' request.")
+    resource_templates_response = await _mcp_request("resources/templates/list")
+    
+    if 'error' in resource_templates_response:
+        print(f"   -> Error: {resource_templates_response['error']}")
+    
+    resource_templates = resource_templates_response.get('result', {}).get('resourceTemplates', [])
+    print(f"   -> Success! Server has {len(resource_templates)} resource templates:")
+    for res in resource_templates:
+        print(f"      - {res.get('uriTemplate')}: {res.get('description')}")
 
-    # 2. Read the static welcome message
-    print("\n[Step 2: Reading a static resource]")
+    # 3. Read the static welcome message
+    print("\n[Step 3: Reading a static resource]")
     print("Now, we'll read the 'app:///messages/welcome' resource.")
     read_params = {"uri": "app:///messages/welcome"}
     read_response = await _mcp_request("resources/read", read_params)
@@ -58,11 +72,11 @@ async def main():
     if 'error' in read_response:
         print(f"   -> Error: {read_response['error']}")
     else:
-        content = read_response.get('result', {}).get('content', [{}])[0].get('text')
+        content = read_response.get('result', {}).get('contents', [{}])[0].get('text')
         print(f"   -> Success! The server returned: '{content}'")
 
-    # 3. Read the dynamic system time
-    print("\n[Step 3: Reading a dynamic resource]")
+    # 4. Read the dynamic system time
+    print("\n[Step 4: Reading a dynamic resource]")
     print("Next, we'll read 'app:///system/time'. This one is generated on the fly.")
     read_params = {"uri": "app:///system/time"}
     read_response = await _mcp_request("resources/read", read_params)
@@ -70,12 +84,12 @@ async def main():
     if 'error' in read_response:
         print(f"   -> Error: {read_response['error']}")
     else:
-        content = read_response.get('result', {}).get('content', [{}])[0]
+        content = read_response.get('result', {}).get('contents', [{}])[0]
         print(f"   -> Success! The server returned a JSON object:")
         print(f"      {json.dumps(content)}")
 
-    # 4. Read a templated user profile
-    print("\n[Step 4: Reading a templated resource]")
+    # 5. Read a templated user profile
+    print("\n[Step 5: Reading a templated resource]")
     print("Finally, we'll read 'users://jane.doe/profile' to get a specific user's data.")
     read_params = {"uri": "users://jane.doe/profile"}
     read_response = await _mcp_request("resources/read", read_params)
@@ -83,7 +97,7 @@ async def main():
     if 'error' in read_response:
         print(f"   -> Error: {read_response['error']}")
     else:
-        content = read_response.get('result', {}).get('content', [{}])[0]
+        content = read_response.get('result', {}).get('contents', [{}])[0]
         print(f"   -> Success! The server returned the user profile:")
         print(f"      {json.dumps(content)}")
 

--- a/03_ai_protocols/02_model_context_protocol/01_server_development/03_exposing_resources/postman/MCP_Exposing_Resources.postman_collection.json
+++ b/03_ai_protocols/02_model_context_protocol/01_server_development/03_exposing_resources/postman/MCP_Exposing_Resources.postman_collection.json
@@ -32,7 +32,7 @@
 			}
 		},
 		{
-			"name": "02. Read Static Resource (Welcome Message)",
+			"name": "02. Discover Resource Templates",
 			"request": {
 				"method": "POST",
 				"header": [
@@ -47,7 +47,33 @@
 				],
 				"body": {
 					"mode": "raw",
-					"raw": "{\n    \"jsonrpc\": \"2.0\",\n    \"method\": \"resources/read\",\n    \"params\": {\n        \"uri\": \"app:///messages/welcome\"\n    },\n    \"id\": 2\n}"
+					"raw": "{\n    \"jsonrpc\": \"2.0\",\n    \"method\": \"resources/templates/list\",\n    \"params\": {},\n    \"id\": 2\n}"
+				},
+				"url": {
+					"raw": "{{baseUrl}}/mcp",
+					"host": ["{{baseUrl}}"],
+					"path": ["mcp"]
+				},
+				"description": "Discover what resource templates the server provides. Resource templates allow for dynamic URI patterns with variables."
+			}
+		},
+		{
+			"name": "03. Read Static Resource (Welcome Message)",
+			"request": {
+				"method": "POST",
+				"header": [
+					{
+						"key": "Content-Type",
+						"value": "application/json"
+					},
+					{
+						"key": "Accept",
+						"value": "application/json, text/event-stream"
+					}
+				],
+				"body": {
+					"mode": "raw",
+					"raw": "{\n    \"jsonrpc\": \"2.0\",\n    \"method\": \"resources/read\",\n    \"params\": {\n        \"uri\": \"app:///messages/welcome\"\n    },\n    \"id\": 3\n}"
 				},
 				"url": {
 					"raw": "{{baseUrl}}/mcp",
@@ -58,7 +84,7 @@
 			}
 		},
 		{
-			"name": "03. Read Dynamic Resource (Server Time)",
+			"name": "04. Read Dynamic Resource (Server Time)",
 			"request": {
 				"method": "POST",
 				"header": [
@@ -73,7 +99,7 @@
 				],
 				"body": {
 					"mode": "raw",
-					"raw": "{\n    \"jsonrpc\": \"2.0\",\n    \"method\": \"resources/read\",\n    \"params\": {\n        \"uri\": \"app:///system/time\"\n    },\n    \"id\": 3\n}"
+					"raw": "{\n    \"jsonrpc\": \"2.0\",\n    \"method\": \"resources/read\",\n    \"params\": {\n        \"uri\": \"app:///system/time\"\n    },\n    \"id\": 4\n}"
 				},
 				"url": {
 					"raw": "{{baseUrl}}/mcp",
@@ -84,7 +110,7 @@
 			}
 		},
 		{
-			"name": "04. Read Templated Resource (User: jane.doe)",
+			"name": "05. Read Templated Resource (User: jane.doe)",
 			"request": {
 				"method": "POST",
 				"header": [
@@ -99,7 +125,7 @@
 				],
 				"body": {
 					"mode": "raw",
-					"raw": "{\n    \"jsonrpc\": \"2.0\",\n    \"method\": \"resources/read\",\n    \"params\": {\n        \"uri\": \"users://jane.doe/profile\"\n    },\n    \"id\": 4\n}"
+					"raw": "{\n    \"jsonrpc\": \"2.0\",\n    \"method\": \"resources/read\",\n    \"params\": {\n        \"uri\": \"users://jane.doe/profile\"\n    },\n    \"id\": 5\n}"
 				},
 				"url": {
 					"raw": "{{baseUrl}}/mcp",
@@ -110,7 +136,7 @@
 			}
 		},
 		{
-			"name": "05. Read Templated Resource (User: john.smith)",
+			"name": "06. Read Templated Resource (User: john.smith)",
 			"request": {
 				"method": "POST",
 				"header": [
@@ -125,7 +151,7 @@
 				],
 				"body": {
 					"mode": "raw",
-					"raw": "{\n    \"jsonrpc\": \"2.0\",\n    \"method\": \"resources/read\",\n    \"params\": {\n        \"uri\": \"users://john.smith/profile\"\n    },\n    \"id\": 5\n}"
+					"raw": "{\n    \"jsonrpc\": \"2.0\",\n    \"method\": \"resources/read\",\n    \"params\": {\n        \"uri\": \"users://john.smith/profile\"\n    },\n    \"id\": 6\n}"
 				},
 				"url": {
 					"raw": "{{baseUrl}}/mcp",
@@ -136,7 +162,7 @@
 			}
 		},
 		{
-			"name": "06. Read Templated Resource (User: alice_123)",
+			"name": "07. Read Templated Resource (User: alice_123)",
 			"request": {
 				"method": "POST",
 				"header": [
@@ -151,7 +177,7 @@
 				],
 				"body": {
 					"mode": "raw",
-					"raw": "{\n    \"jsonrpc\": \"2.0\",\n    \"method\": \"resources/read\",\n    \"params\": {\n        \"uri\": \"users://alice_123/profile\"\n    },\n    \"id\": 6\n}"
+					"raw": "{\n    \"jsonrpc\": \"2.0\",\n    \"method\": \"resources/read\",\n    \"params\": {\n        \"uri\": \"users://alice_123/profile\"\n    },\n    \"id\": 7\n}"
 				},
 				"url": {
 					"raw": "{{baseUrl}}/mcp",
@@ -162,7 +188,7 @@
 			}
 		},
 		{
-			"name": "07. Read Templated Resource (Special Characters)",
+			"name": "08. Read Templated Resource (Special Characters)",
 			"request": {
 				"method": "POST",
 				"header": [
@@ -177,7 +203,7 @@
 				],
 				"body": {
 					"mode": "raw",
-					"raw": "{\n    \"jsonrpc\": \"2.0\",\n    \"method\": \"resources/read\",\n    \"params\": {\n        \"uri\": \"users://user-with-dashes/profile\"\n    },\n    \"id\": 7\n}"
+					"raw": "{\n    \"jsonrpc\": \"2.0\",\n    \"method\": \"resources/read\",\n    \"params\": {\n        \"uri\": \"users://user-with-dashes/profile\"\n    },\n    \"id\": 8\n}"
 				},
 				"url": {
 					"raw": "{{baseUrl}}/mcp",
@@ -188,7 +214,7 @@
 			}
 		},
 		{
-			"name": "08. Multiple Time Requests (Compare Dynamic)",
+			"name": "09. Multiple Time Requests (Compare Dynamic)",
 			"request": {
 				"method": "POST",
 				"header": [
@@ -203,7 +229,7 @@
 				],
 				"body": {
 					"mode": "raw",
-					"raw": "{\n    \"jsonrpc\": \"2.0\",\n    \"method\": \"resources/read\",\n    \"params\": {\n        \"uri\": \"app:///system/time\"\n    },\n    \"id\": 8\n}"
+					"raw": "{\n    \"jsonrpc\": \"2.0\",\n    \"method\": \"resources/read\",\n    \"params\": {\n        \"uri\": \"app:///system/time\"\n    },\n    \"id\": 9\n}"
 				},
 				"url": {
 					"raw": "{{baseUrl}}/mcp",
@@ -214,7 +240,7 @@
 			}
 		},
 		{
-			"name": "09. Error: Invalid Resource URI",
+			"name": "10. Error: Invalid Resource URI",
 			"request": {
 				"method": "POST",
 				"header": [
@@ -229,7 +255,7 @@
 				],
 				"body": {
 					"mode": "raw",
-					"raw": "{\n    \"jsonrpc\": \"2.0\",\n    \"method\": \"resources/read\",\n    \"params\": {\n        \"uri\": \"app:///nonexistent/resource\"\n    },\n    \"id\": 9\n}"
+					"raw": "{\n    \"jsonrpc\": \"2.0\",\n    \"method\": \"resources/read\",\n    \"params\": {\n        \"uri\": \"app:///nonexistent/resource\"\n    },\n    \"id\": 10\n}"
 				},
 				"url": {
 					"raw": "{{baseUrl}}/mcp",


### PR DESCRIPTION
## Add Resource Templates Discovery to MCP Example

### Changes
- **client.py**: Added `resources/templates/list` demonstration (new Step 2)
- **Postman collection**: Added "02. Discover Resource Templates" request, renumbered 03-10
- **Fixed retrieval**: Replace `content` with `contents` for correct MCP specification compliance

### Educational Value
Complete MCP workflow: discover resources → discover templates → read resources

### Files Modified
- `my_resources_server/client.py`: Added template discovery step, fixed content→contents usage
- `postman/MCP_Exposing_Resources.postman_collection.json`: Added template request, updated numbering

Helps students understand the full MCP resource capabilities and proper specification usage.