### PR TITLE
Fix: Improve tool naming, and validation in agent examples

### DIFF
--- a/01_ai_agents_first/15_run_lifecycle/run_lifecycle.ipynb
+++ b/01_ai_agents_first/15_run_lifecycle/run_lifecycle.ipynb
@@ -122,7 +122,7 @@
     },
     {
       "cell_type": "code",
-      "execution_count": 53,
+      "execution_count": null,
       "metadata": {
         "id": "xL1SE0WBzNfB"
       },
@@ -133,7 +133,8 @@
         "import random\n",
         "from typing import Any\n",
         "\n",
-        "from agents import Agent, RunContextWrapper, RunHooks, Runner, Tool, Usage, function_tool"
+        "from agents import Agent, RunContextWrapper, RunHooks, Runner, Tool, Usage, function_tool\n",
+        "import sys"
       ]
     },
     {
@@ -289,7 +290,7 @@
     },
     {
       "cell_type": "code",
-      "execution_count": 59,
+      "execution_count": null,
       "metadata": {
         "colab": {
           "base_uri": "https://localhost:8080/"
@@ -323,15 +324,19 @@
         "\n",
         "\n",
         "@function_tool(\"random_number\")\n",
-        "def random_number(max: int) -> int:\n",
-        "    \"\"\"Generate a random number up to the provided max.\"\"\"\n",
-        "    return random.randint(0, max)\n",
+        "def random_number(max_value: int) -> int:\n",
+        "    \"\"\"Generate a random number between 0 and the provided max_value (inclusive).\"\"\"\n",
+        "    return random.randint(0, max_value)\n",
         "\n",
         "\n",
+        "# Safer tool usage and prevents bugs if wrong type is passed.\n",
         "@function_tool(\"multiply_by_two\")\n",
         "def multiply_by_two(x: int) -> int:\n",
         "    \"\"\"Return x times two.\"\"\"\n",
+        "    if not isinstance(x, int):\n",
+        "        raise ValueError(\"Expected integer input.\")\n",
         "    return x * 2\n",
+        "\n",
         "\n",
         "\n",
         "multiply_agent = Agent(\n",


### PR DESCRIPTION
### Changes Made

This PR makes the example code in `openai-agents` more robust, safe, and production-friendly by fixing several issues:

1. **Renamed tool argument `max`** to avoid shadowing Python built-in.
2. **Added input validation** to `multiply_by_two()` tool.

### Why These Changes?

- Using `max` as a variable name can cause confusion or bugs.
- Tool functions should validate input and fail early if types are wrong.


This improves reliability and developer experience for anyone building with `openai-agents`.
