### PR TITLE
uv add mcp uvicorn httpx change it with uv add mcp httpx

### DIFF
--- a/03_ai_protocols/01_mcp/04_fundamental_ primitives/01_hello_mcp_server/readme.md
+++ b/03_ai_protocols/01_mcp/04_fundamental_ primitives/01_hello_mcp_server/readme.md
@@ -60,7 +60,7 @@ Inside the `hello-mcp/` subdirectory, we will:
     - Install the necessary packages using `uv`:
 
       ```bash
-      uv add mcp uvicorn httpx
+      uv add mcp httpx
       ```
 
 3.  Update (`server.py`):

--- a/03_ai_protocols/01_mcp/05_capabilities_and_transport/02_stateful_http_lifecycle/README.md
+++ b/03_ai_protocols/01_mcp/05_capabilities_and_transport/02_stateful_http_lifecycle/README.md
@@ -213,7 +213,7 @@ Per the specification:
 
 ### **Terminal 1: Start the Enhanced Server**
 ```bash
-uv add mcp uvicorn httpx
+uv add mcp httpx
 uv run uvicorn server:mcp_app --host 0.0.0.0 --port 8000 --reload
 ```
 


### PR DESCRIPTION
This pull request simplifies the installation command for the documentation.

Currently, the documentation instructs users to run `uv add mcp uvicorn httpx`. However, `uvicorn` is installed automatically as a dependency of `mcp`. This change removes the redundant `uvicorn` package from the command.

This update makes the installation process more concise and accurate, improving the overall user experience for new developers.